### PR TITLE
[canary-publish] Add multilingual support and enhance release creation inputs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
-### 이슈 <!-- #뒤에 이슈번호 작성 -->
+### Issue <!-- Write the issue number after # -->
 
 - NaverPayDev/changeset-actions#
 
-### 작업 유형
+### Type of Work
 
-- [ ] 버그 수정
-- [ ] 기능 추가
-- [ ] 코드 개선
+- [ ] Bug Fix
+- [ ] Feature Addition
+- [ ] Code Improvement
 
-### 작업 내용 <!-- PR의 주요 작업 내용 작성 -->
-
--
--
--
-
-### PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->
+### Description of Work <!-- Briefly describe the main work done in this PR -->
 
 -
 -
 -
 
-### 기타 <!-- 기타 적고싶은 내용(TODO, 참고링크 등) 기재. 없으면 생략 -->
+### Review Points <!-- Points you want reviewers to focus on (references, details, etc.) -->
+
+-
+-
+-
+
+### Others <!-- Any additional notes (TODOs, reference links, etc.). Omit if not applicable -->

--- a/canary-publish/README.ko.md
+++ b/canary-publish/README.ko.md
@@ -41,12 +41,16 @@ jobs:
             - name: Canary Publish
               uses: NaverPayDev/changeset-actions/canary-publish@main
               with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }} # 필요하면 user의 PAT을 넣어주세요.
-                  npm_tag: canary # npm 배포 시 달아줄 태그는 무엇으로 할지적어주세요
-                  npm_token: ${{ secrets.NPM_TOKEN }} # npm 배포시 필요한 publish token 을 넣어주세요 
-                  publish_script: pnpm run deploy:canary # canary 배포 실행 script 를 넣어주세요
-                  packages_dir: packages # 변경을 탐지할 패키지들의 폴더명을 추가해주세요. (default: packages,share)       
-                  excludes: ".turbo,.github" # 변경감지를 제외하고싶은 파일 또는 폴더 경로      
+                  github_token: ${{ secrets.GITHUB_TOKEN }}           # (필수) GitHub API 인증 토큰. 필요시 사용자 PAT로 대체 가능
+                  npm_tag: canary                                    # (선택) 배포에 사용할 npm 태그 (예: canary, beta 등)
+                  npm_token: ${{ secrets.NPM_TOKEN }}                # (필수) npm publish를 위한 인증 토큰
+                  publish_script: pnpm run deploy:canary             # (필수) Canary 배포를 실행할 스크립트 명령어
+                  packages_dir: packages                             # (선택) 변경 감지에 사용할 패키지 디렉터리 (기본값: packages,share)
+                  excludes: ".turbo,.github"                         # (선택) 변경 감지에서 제외할 파일/디렉터리 목록 (쉼표로 구분)
+                  version_template: '{VERSION}-canary.{DATE}-{COMMITID7}' # (선택) Canary 버전명 템플릿
+                  dry_run: false                                     # (선택) true면 실제 배포 없이 시뮬레이션만 수행
+                  language: 'en'                                     # (선택) 메시지 언어 설정 (en, ko 등)
+                  create_release: false                              # (선택) true면 Canary 배포 후 GitHub Release 자동 생성   
 ```
 
 ## 실행 결과

--- a/canary-publish/README.md
+++ b/canary-publish/README.md
@@ -41,12 +41,16 @@ jobs:
             - name: Canary Publish
               uses: NaverPayDev/changeset-actions/canary-publish@main
               with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }} # Add user PAT if necessary
-                  npm_tag: canary # Specify the npm tag to use for deployment
-                  npm_token: ${{ secrets.NPM_TOKEN }} # Provide the token required for npm publishing
-                  publish_script: pnpm run deploy:canary # Script to execute Canary deployment
-                  packages_dir: packages # Directory of packages to detect changes (default: packages,share)
-                  excludes: ".turbo,.github" # Files or directories to exclude from change detection
+                  github_token: ${{ secrets.GITHUB_TOKEN }}           # (Required) GitHub API token for authentication. Use a user PAT if necessary.
+                  npm_tag: canary                                    # (Optional) The npm tag to use for deployment (e.g., canary, beta).
+                  npm_token: ${{ secrets.NPM_TOKEN }}                # (Required) Token used for npm publishing.
+                  publish_script: pnpm run deploy:canary             # (Required) Script command to execute the canary deployment.
+                  packages_dir: packages                             # (Optional) Directory containing packages to check for changes (default: packages,share).
+                  excludes: ".turbo,.github"                         # (Optional) Files or directories to exclude from change detection (comma-separated).
+                  version_template: '{VERSION}-canary.{DATE}-{COMMITID7}' # (Optional) Template for the canary version string.
+                  dry_run: false                                     # (Optional) If true, performs a dry run without publishing.
+                  language: 'en'                                     # (Optional) Language for output messages (e.g., en, ko).
+                  create_release: false                              # (Optional) If true, creates a GitHub Release after canary publishing.
 ```
 
 ## Execution Results

--- a/canary-publish/action.yml
+++ b/canary-publish/action.yml
@@ -33,3 +33,7 @@ inputs:
         description: 'only log packages to canary without publishing'
         required: false
         default: 'false'
+    create_release:
+        description: 'create release with package and version'
+        required: false
+        default: 'false'

--- a/canary-publish/action.yml
+++ b/canary-publish/action.yml
@@ -37,3 +37,7 @@ inputs:
         description: 'create release with package and version'
         required: false
         default: 'false'
+    language:
+        description: 'language for release note, comment etc.'
+        required: false
+        default: 'en'

--- a/canary-publish/action.yml
+++ b/canary-publish/action.yml
@@ -1,27 +1,35 @@
-name: "changesets-canary-publish"
-description: "changesets canary publish"
+name: 'changesets-canary-publish'
+description: 'changesets canary publish'
 runs:
-    using: "node16"
-    main: "dist/index.js"
+    using: 'node16'
+    main: 'dist/index.js'
 inputs:
     github_token:
-        description: "github token"
+        description: 'github token'
         required: true
     npm_tag:
-        description: "npm tag"
+        description: 'npm tag'
         default: canary
         required: false
     npm_token:
-        description: "npm token"
+        description: 'npm token'
         required: true
     publish_script:
-        description: "canary deploy script"
+        description: 'canary deploy script'
         required: true
     packages_dir:
-        description: "패키지 디렉터리"
+        description: '패키지 디렉터리'
         required: false
-        default: "packages,share"
-    excludes: 
-        description: "제외할 경로"
+        default: 'packages,share'
+    excludes:
+        description: '제외할 경로'
         required: false
-        default: ".github,.changeset"
+        default: '.github,.changeset'
+    version_template:
+        description: 'package version template for canary (variables: VERSION, DATE, COMMITID7)'
+        required: false
+        default: '{VERSION}-canary-{COMMITID7}'
+    dry_run:
+        description: 'only log packages to canary without publishing'
+        required: false
+        default: 'false'

--- a/canary-publish/dist/index.js
+++ b/canary-publish/dist/index.js
@@ -53365,13 +53365,13 @@ function main() {
                     var _a;
                     return (_a = replacements[key]) !== null && _a !== void 0 ? _a : '';
                 });
-                core.info(`✅ [${packageJson.name}] 이전 버전: ${packageJson.version} / 😘 새로운 버전: ${newVersion}`);
+                core.info(`✅ [${packageJson.name}] Previous version: ${packageJson.version} / 😘 Next version: ${newVersion}`);
                 packageJson.version = newVersion;
                 fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8');
             });
             const dryRun = core.getBooleanInput('dry_run');
             if (dryRun) {
-                core.info('카나리 배포를 위한 dry run 입니다.');
+                core.info('This is dry run for Canary distribution.');
                 return;
             }
             // 변경된 버전으로 카나리 배포
@@ -53490,7 +53490,7 @@ function protectUnchangedPackages(changedPackages) {
         for (const packageJsonPath of allPackageJSON) {
             if (!changedPackages.includes(packageJsonPath)) {
                 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-                core.info(`🔨 [${packageJson.name}] private:true 를 추가합니다`);
+                core.info(`🔨 [${packageJson.name}] Add private:true option.`);
                 packageJson.private = true;
                 fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8');
             }
@@ -53502,7 +53502,7 @@ function removeChangesetMdFiles(_a) {
         const markdownPaths = yield (0, fast_glob_1.default)('.changeset/*.md');
         return Promise.all(markdownPaths.map((markdownPath) => __awaiter(this, void 0, void 0, function* () {
             if (changedFiles.find(({ filename }) => filename === markdownPath) == null) {
-                console.log(`PR과 관련없는 ${markdownPath} 제거`); // eslint-disable-line
+                console.log(`Remove ${markdownPath} unrelated to PR`); // eslint-disable-line
                 yield fs.remove(markdownPath);
             }
         })));

--- a/canary-publish/src/constants/lang.ts
+++ b/canary-publish/src/constants/lang.ts
@@ -1,0 +1,12 @@
+export const LANGUAGES = {
+    en: {
+        empty: 'No changed files exist under the {PATH} path, no packages have been deployed.',
+        error: 'An error occurred during the canary deployment.',
+        failure: 'Please specify the detect version for a valid canary version deployment',
+    },
+    ko: {
+        empty: '{PATH} 하위 변경된 파일이 없어, 배포된 패키지가 없습니다.',
+        error: '카나리 배포 도중 에러가 발생했습니다.',
+        failure: '올바른 카나리 버전 배포를 위해 detect version을 명시해주세요',
+    },
+}

--- a/canary-publish/src/index.ts
+++ b/canary-publish/src/index.ts
@@ -9,7 +9,7 @@ import {getChangedAllFiles} from '$actions/utils'
 
 import {getChangedPackages, protectUnchangedPackages, removeChangesetMdFiles} from './utils/file'
 import {setNpmRc} from './utils/npm'
-import {getPublishedPackageInfos} from './utils/publish'
+import {createReleaseForTags, getPublishedPackageInfos} from './utils/publish'
 
 const cwd = process.cwd()
 
@@ -140,6 +140,10 @@ async function main() {
             execOutput: changesetPublishOutput,
             packagesDir,
         })
+
+        const createRelease = core.getBooleanInput('create_release')
+
+        createRelease && (await createReleaseForTags(publishedPackages.map(({name, version}) => `${name}@${version}`)))
 
         // 배포 완료 코멘트
         await issueFetchers.addComment(message)

--- a/canary-publish/src/index.ts
+++ b/canary-publish/src/index.ts
@@ -116,7 +116,9 @@ async function main() {
                 },
             )
 
-            core.info(`✅ [${packageJson.name}] 이전 버전: ${packageJson.version} / 😘 새로운 버전: ${newVersion}`)
+            core.info(
+                `✅ [${packageJson.name}] Previous version: ${packageJson.version} / 😘 Next version: ${newVersion}`,
+            )
 
             packageJson.version = newVersion
 
@@ -126,7 +128,7 @@ async function main() {
         const dryRun = core.getBooleanInput('dry_run')
 
         if (dryRun) {
-            core.info('카나리 배포를 위한 dry run 입니다.')
+            core.info('This is dry run for Canary distribution.')
             return
         }
 

--- a/canary-publish/src/utils/file.ts
+++ b/canary-publish/src/utils/file.ts
@@ -56,7 +56,7 @@ export async function protectUnchangedPackages(changedPackages: string[]) {
         if (!changedPackages.includes(packageJsonPath)) {
             const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
 
-            core.info(`🔨 [${packageJson.name}] private:true 를 추가합니다`)
+            core.info(`🔨 [${packageJson.name}] Add private:true option.`)
 
             packageJson.private = true
 
@@ -75,7 +75,7 @@ export async function removeChangesetMdFiles({
     return Promise.all(
         markdownPaths.map(async (markdownPath) => {
             if (changedFiles.find(({filename}) => filename === markdownPath) == null) {
-                console.log(`PR과 관련없는 ${markdownPath} 제거`) // eslint-disable-line
+                console.log(`Remove ${markdownPath} unrelated to PR`) // eslint-disable-line
 
                 await fs.remove(markdownPath)
             }

--- a/canary-publish/src/utils/publish.ts
+++ b/canary-publish/src/utils/publish.ts
@@ -7,7 +7,7 @@ export function getPublishedPackageInfos({packagesDir, execOutput}: {execOutput:
 
     for (const publishOutput of execOutput.stdout.split('\n')) {
         // eslint-disable-next-line no-useless-escape
-        const regExp = /^(🦋 {2})([A-Za-z-\d\/\@]+@)(\d+\.\d+\.\d+\-[A-Za-z]+\-\w{7})$/
+        const regExp = /^(🦋 {2})([A-Za-z-\d\/\@]+@)(.+)$/
         const matchResult = publishOutput.trim().match(regExp)
         if (!matchResult) {
             continue

--- a/canary-publish/src/utils/publish.ts
+++ b/canary-publish/src/utils/publish.ts
@@ -1,4 +1,7 @@
-import {ExecOutput} from '@actions/exec'
+import {execSync} from 'node:child_process'
+
+import * as core from '@actions/core'
+import {ExecOutput, exec} from '@actions/exec'
 
 import {uniqBy} from '$actions/utils'
 
@@ -28,5 +31,28 @@ export function getPublishedPackageInfos({packagesDir, execOutput}: {execOutput:
     return {
         message,
         publishedPackages: uniqPackages,
+    }
+}
+
+export async function createReleaseForTags(tags: string[]) {
+    for (const tag of tags) {
+        // 이미 Release가 생성된 태그는 건너뜀
+        try {
+            await exec('gh', ['release', 'view', tag])
+            core.info(`Release already exists for tag: ${tag}`)
+            continue
+        } catch {
+            // IGNORE: release가 없으면 진행
+        }
+
+        // 커밋 로그 추출하여 릴리즈 노트 생성
+        const notes = execSync(`git log ${tag}^..${tag} --pretty=format:"- %s"`, {encoding: 'utf8'})
+
+        /**
+         * GitHub Release 생성
+         * @see https://cli.github.com/manual/gh_release_create
+         */
+        await exec('gh', ['release', 'create', tag, '--title', tag, '--notes', notes || 'No changes', '--prerelease'])
+        core.info(`Created Release for tag: ${tag}`)
     }
 }

--- a/canary-publish/src/utils/publish.ts
+++ b/canary-publish/src/utils/publish.ts
@@ -2,10 +2,19 @@ import {execSync} from 'node:child_process'
 
 import * as core from '@actions/core'
 import {ExecOutput, exec} from '@actions/exec'
+import {LANGUAGES} from 'canary-publish/src/constants/lang'
 
 import {uniqBy} from '$actions/utils'
 
-export function getPublishedPackageInfos({packagesDir, execOutput}: {execOutput: ExecOutput; packagesDir: string}) {
+export function getPublishedPackageInfos({
+    packagesDir,
+    execOutput,
+    language,
+}: {
+    execOutput: ExecOutput
+    packagesDir: string
+    language: 'ko' | 'en'
+}) {
     const publishedPackages = []
 
     for (const publishOutput of execOutput.stdout.split('\n')) {
@@ -26,7 +35,7 @@ export function getPublishedPackageInfos({packagesDir, execOutput}: {execOutput:
     const message =
         uniqPackages.length > 0
             ? ['## Published Canary Packages', '', '', '```', `${copyCodeBlock}`, '```'].join('\n')
-            : `${packagesDir} 하위 변경된 파일이 없어, 배포된 패키지가 없습니다.`
+            : LANGUAGES[language].empty.replace('{PATH}', packagesDir)
 
     return {
         message,


### PR DESCRIPTION
### 이슈 <!-- #뒤에 이슈번호 작성 -->

- NaverPayDev/changeset-actions#19

### 작업 유형

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 개선

### 작업 내용 <!-- PR의 주요 작업 내용 작성 -->

This pull request introduces the following changes to enhance the release process:

- Multilingual comments: Added a `language` input to support multilingual release notes. Ensures better localization for release documentation.
- Enhanced Release Creation: Added a `create_release` input to enable GitHub release creation. Implemented the createReleaseForTags function in publish.ts for streamlined release generation.
- Improved Canary Publish: Added `version_template` and `dry_run` inputs for better control over canary publishing.
Adjusted regex in publish.ts for improved version matching.


### PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

-
-
-

### 기타 <!-- 기타 적고싶은 내용(TODO, 참고링크 등) 기재. 없으면 생략 -->

- Next: Improve detect-add action