### PR TITLE
[canary-publish] Fix `create_release`-related logic.

### DIFF
--- a/canary-publish/README.ko.md
+++ b/canary-publish/README.ko.md
@@ -50,7 +50,7 @@ jobs:
                   version_template: '{VERSION}-canary.{DATE}-{COMMITID7}' # (선택) Canary 버전명 템플릿
                   dry_run: false                                     # (선택) true면 실제 배포 없이 시뮬레이션만 수행
                   language: 'en'                                     # (선택) 메시지 언어 설정 (en, ko 등)
-                  create_release: false                              # (선택) true면 Canary 배포 후 GitHub Release 자동 생성   
+                  create_release: false                              # (선택) true면 Canary 배포 후 GitHub  Release 자동 생성. 반드시 @action/checkout에 `fetch-depth: 0` with 옵션을 주세요.
 ```
 
 ## 실행 결과

--- a/canary-publish/README.md
+++ b/canary-publish/README.md
@@ -50,7 +50,7 @@ jobs:
                   version_template: '{VERSION}-canary.{DATE}-{COMMITID7}' # (Optional) Template for the canary version string.
                   dry_run: false                                     # (Optional) If true, performs a dry run without publishing.
                   language: 'en'                                     # (Optional) Language for output messages (e.g., en, ko).
-                  create_release: false                              # (Optional) If true, creates a GitHub Release after canary publishing.
+                  create_release: false                              # (Optional) If true, creates a GitHub Release after canary publishing. Make sure to add `fetch-depth: 0` `with` option to @action/checkout.
 ```
 
 ## Execution Results

--- a/canary-publish/action.yml
+++ b/canary-publish/action.yml
@@ -34,7 +34,7 @@ inputs:
         required: false
         default: 'false'
     create_release:
-        description: 'create release with package and version'
+        description: 'create release with package and version (If true, you must set `fetch-depth: 0` in @action/checkout)'
         required: false
         default: 'false'
     language:

--- a/canary-publish/src/index.ts
+++ b/canary-publish/src/index.ts
@@ -148,7 +148,12 @@ async function main() {
 
         const createRelease = core.getBooleanInput('create_release')
 
-        createRelease && (await createReleaseForTags(publishedPackages.map(({name, version}) => `${name}@${version}`)))
+        createRelease &&
+            (await createReleaseForTags({
+                tags: publishedPackages.map(({name, version}) => `${name}@${version}`),
+                baseSha: pullRequestInfo.base.sha,
+                headSha: pullRequestInfo.head.sha,
+            }))
 
         // 배포 완료 코멘트
         await issueFetchers.addComment(message)
@@ -160,6 +165,7 @@ async function main() {
     } catch (e) {
         core.error((e as Error)?.message)
         issueFetchers.addComment(LANGUAGES[language].error)
+        process.exit(1) // close with error
     }
 }
 

--- a/canary-publish/src/utils/publish.ts
+++ b/canary-publish/src/utils/publish.ts
@@ -43,7 +43,15 @@ export function getPublishedPackageInfos({
     }
 }
 
-export async function createReleaseForTags(tags: string[]) {
+export async function createReleaseForTags({
+    tags,
+    baseSha,
+    headSha,
+}: {
+    tags: string[]
+    baseSha: string
+    headSha: string
+}) {
     for (const tag of tags) {
         // 이미 Release가 생성된 태그는 건너뜀
         try {
@@ -55,7 +63,7 @@ export async function createReleaseForTags(tags: string[]) {
         }
 
         // 커밋 로그 추출하여 릴리즈 노트 생성
-        const notes = execSync(`git log ${tag}^..${tag} --pretty=format:"- %s"`, {encoding: 'utf8'})
+        const notes = execSync(`git log ${baseSha}..${headSha} --pretty=format:"- %s"`, {encoding: 'utf8'})
 
         /**
          * GitHub Release 생성


### PR DESCRIPTION
### Issue <!-- Write the issue number after # -->

- NaverPayDev/changeset-actions#19

### Type of Work

- [x] Bug Fix
- [ ] Feature Addition
- [ ] Code Improvement

### Description of Work <!-- Briefly describe the main work done in this PR -->

- There is no tag when publish_script is `changeset publish --no-git-tag` like. 
- Although user don't create git tag when publishing packages, canary action creates a git tag when `gh release` so that `--no-git-tag` is still acceptable. 
- But, when getting commit logs based on this tag, an error occured because a tag is not created yet.
- So, I fixed logic of getting commit logs by getting logs between baseSha and headSha.
- Due to this modification, if `create_release` is true, user must set the @action/checkout with `fetch-depth: 0` for getting correct release changelogs.

### Review Points <!-- Points you want reviewers to focus on (references, details, etc.) -->

-
-
-

### Others <!-- Any additional notes (TODOs, reference links, etc.). Omit if not applicable -->
