### PR TITLE
feat(detect-add): Fork PR에 대한 changeset 가이드 기능 추가

### DIFF
--- a/detect-add/action.yml
+++ b/detect-add/action.yml
@@ -30,3 +30,10 @@ inputs:
         description: 'language to use for the changeset'
         required: false
         default: 'en'
+    fork_guide_enabled:
+        description: 'enable guide comment for fork PRs (fork PRs cannot use auto-detect due to token permissions)'
+        required: false
+        default: 'false'
+    fork_guide_message:
+        description: 'custom guide message for fork PRs (optional, uses default bilingual message if not provided)'
+        required: false

--- a/detect-add/dist/index.js
+++ b/detect-add/dist/index.js
@@ -57338,7 +57338,7 @@ const file_1 = __nccwpck_require__(398);
 const get_release_plan_1 = __nccwpck_require__(6240);
 function main() {
     return __awaiter(this, void 0, void 0, function* () {
-        var _a, _b, _c, _d;
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m;
         const context = github.context;
         const { pull_request } = context.payload;
         if (!pull_request) {
@@ -57382,11 +57382,74 @@ function main() {
                 : `The base branch is ${pull_request.base.ref}, or the head branch is ${(_c = pull_request === null || pull_request === void 0 ? void 0 : pull_request.head) === null || _c === void 0 ? void 0 : _c.ref}, so detectAdd is skipped.`);
             return;
         }
+        // Fork PR 감지 및 가이드 코멘트 처리
+        const forkGuideEnabled = core.getInput('fork_guide_enabled') === 'true';
+        const isForkPR = ((_e = (_d = pull_request.head) === null || _d === void 0 ? void 0 : _d.repo) === null || _e === void 0 ? void 0 : _e.fork) === true || ((_g = (_f = pull_request.head) === null || _f === void 0 ? void 0 : _f.repo) === null || _g === void 0 ? void 0 : _g.full_name) !== `${owner}/${repo}`;
+        if (isForkPR) {
+            core.info(isKoreanLanguage
+                ? `Fork PR이 감지되었습니다. (${(_j = (_h = pull_request.head) === null || _h === void 0 ? void 0 : _h.repo) === null || _j === void 0 ? void 0 : _j.full_name})`
+                : `Fork PR detected. (${(_l = (_k = pull_request.head) === null || _k === void 0 ? void 0 : _k.repo) === null || _l === void 0 ? void 0 : _l.full_name})`);
+            if (forkGuideEnabled) {
+                const customMessage = core.getInput('fork_guide_message');
+                const defaultMessage = `## Changeset Guide for External Contributors
+
+**한국어** | [English](#english)
+
+### 한국어
+
+외부 기여자분께 감사드립니다! 🎉
+
+패키지에 변경사항이 있는 경우, changeset 파일을 수동으로 생성해주세요.
+
+\`\`\`bash
+pnpm changeset
+\`\`\`
+
+위 명령어를 실행하면 변경된 패키지와 버전 타입(patch/minor/major)을 선택하고, 변경 내용을 입력할 수 있습니다.
+
+생성된 \`.changeset/*.md\` 파일을 커밋에 포함해주세요.
+
+> **참고**: \`${skipLabel}\` 레이블이 있으면 changeset이 필요하지 않습니다.
+
+---
+
+<a name="english"></a>
+### English
+
+Thank you for your contribution! 🎉
+
+If your PR includes package changes, please create a changeset file manually.
+
+\`\`\`bash
+pnpm changeset
+\`\`\`
+
+This command will guide you to select the changed packages, version type (patch/minor/major), and enter a description.
+
+Please include the generated \`.changeset/*.md\` file in your commit.
+
+> **Note**: If the \`${skipLabel}\` label is present, changeset is not required.
+
+<!-- ${constants_1.CHANGESET_DETECT_ADD_ACTIONS_CHECKSUM} -->`;
+                const guideMessage = customMessage || defaultMessage;
+                const guideComment = Object.assign(Object.assign({}, commonParams), { body: guideMessage });
+                if (prevComment !== undefined) {
+                    yield octokit.rest.issues.updateComment(Object.assign(Object.assign({}, guideComment), { comment_id: prevComment.id }));
+                }
+                else {
+                    yield octokit.rest.issues.createComment(guideComment);
+                }
+                core.info(isKoreanLanguage
+                    ? `Fork PR에 changeset 가이드 코멘트를 추가했습니다.`
+                    : `Added changeset guide comment for fork PR.`);
+            }
+            return;
+        }
         /**
          * 변경된 파일 이름을 가져오기위한 api
          */
         const packages_dir = core.getInput('packages_dir');
-        const excludes = (_d = core.getInput('excludes')) !== null && _d !== void 0 ? _d : '';
+        const excludes = (_m = core.getInput('excludes')) !== null && _m !== void 0 ? _m : '';
         if (typeof packages_dir !== 'string') {
             throw new Error(isKoreanLanguage
                 ? `해당 action에 주입된 packages_dir parameter가 잘못되었습니다. (string, string1)의 형식으로 작성해주세요.`

--- a/detect-add/src/index.ts
+++ b/detect-add/src/index.ts
@@ -76,6 +76,78 @@ async function main() {
         return
     }
 
+    // Fork PR 감지 및 가이드 코멘트 처리
+    const forkGuideEnabled = core.getInput('fork_guide_enabled') === 'true'
+    const isForkPR = pull_request.head?.repo?.fork === true || pull_request.head?.repo?.full_name !== `${owner}/${repo}`
+
+    if (isForkPR) {
+        core.info(
+            isKoreanLanguage
+                ? `Fork PR이 감지되었습니다. (${pull_request.head?.repo?.full_name})`
+                : `Fork PR detected. (${pull_request.head?.repo?.full_name})`,
+        )
+
+        if (forkGuideEnabled) {
+            const customMessage = core.getInput('fork_guide_message')
+            const defaultMessage = `## Changeset Guide for External Contributors
+
+**한국어** | [English](#english)
+
+### 한국어
+
+외부 기여자분께 감사드립니다! 🎉
+
+패키지에 변경사항이 있는 경우, changeset 파일을 수동으로 생성해주세요.
+
+\`\`\`bash
+pnpm changeset
+\`\`\`
+
+위 명령어를 실행하면 변경된 패키지와 버전 타입(patch/minor/major)을 선택하고, 변경 내용을 입력할 수 있습니다.
+
+생성된 \`.changeset/*.md\` 파일을 커밋에 포함해주세요.
+
+> **참고**: \`${skipLabel}\` 레이블이 있으면 changeset이 필요하지 않습니다.
+
+---
+
+<a name="english"></a>
+### English
+
+Thank you for your contribution! 🎉
+
+If your PR includes package changes, please create a changeset file manually.
+
+\`\`\`bash
+pnpm changeset
+\`\`\`
+
+This command will guide you to select the changed packages, version type (patch/minor/major), and enter a description.
+
+Please include the generated \`.changeset/*.md\` file in your commit.
+
+> **Note**: If the \`${skipLabel}\` label is present, changeset is not required.
+
+<!-- ${CHANGESET_DETECT_ADD_ACTIONS_CHECKSUM} -->`
+
+            const guideMessage = customMessage || defaultMessage
+            const guideComment = {...commonParams, body: guideMessage}
+
+            if (prevComment !== undefined) {
+                await octokit.rest.issues.updateComment({...guideComment, comment_id: prevComment.id})
+            } else {
+                await octokit.rest.issues.createComment(guideComment)
+            }
+
+            core.info(
+                isKoreanLanguage
+                    ? `Fork PR에 changeset 가이드 코멘트를 추가했습니다.`
+                    : `Added changeset guide comment for fork PR.`,
+            )
+        }
+        return
+    }
+
     /**
      * 변경된 파일 이름을 가져오기위한 api
      */


### PR DESCRIPTION
## Summary

Fork PR에서 changeset 자동 감지가 실패하는 문제를 해결하기 위해 가이드 코멘트 기능을 추가합니다.

Closes #30

## 새로운 옵션

| 옵션 | 설명 | 기본값 |
|------|------|--------|
| `fork_guide_enabled` | Fork PR에 가이드 코멘트 활성화 | `false` |
| `fork_guide_message` | 커스텀 가이드 메시지 (선택) | 기본 한글/영어 메시지 |

## 사용 예시

```yaml
- uses: NaverPayDev/changeset-actions/detect-add@main
  with:
      github_token: ${{ secrets.ACTION_TOKEN }}
      fork_guide_enabled: true
```

## 동작

| PR 유형 | `fork_guide_enabled: true` | `fork_guide_enabled: false` |
|---------|---------------------------|----------------------------|
| 내부 PR | 기존대로 자동 changeset 감지 | 기존대로 자동 changeset 감지 |
| Fork PR | 한글/영어 가이드 코멘트 추가 | 아무 동작 없음 (기존과 동일) |

## 기본 가이드 메시지

Fork PR 생성 시 아래와 같은 한글/영어 가이드 코멘트가 자동으로 추가됩니다:

- changeset 수동 생성 방법 (\`pnpm changeset\`)
- skip 레이블 안내