### PR TITLE
:wrench: chore: plugin 이름을 naverpay-changeset으로 업데이트

### DIFF
--- a/detect-add/dist/index.js
+++ b/detect-add/dist/index.js
@@ -57405,12 +57405,12 @@ function main() {
 **marketplace 추가 & changeset plugin 설치**
 \`\`\`
 /plugin marketplace add NaverPayDev/naverpay-plugins
-/plugin install changeset@naverpay-plugins
+/plugin install naverpay-changeset@naverpay-plugins
 \`\`\`
 
 **사용법**
 \`\`\`
-/naverpay-plugins:changeset
+/naverpay-changeset:changeset
 \`\`\`
 
 플러그인을 사용하지 않는다면, 아래 명령어를 실행하면 변경된 패키지와 버전 타입(patch/minor/major)을 선택하고, 변경 내용을 입력할 수 있습니다.
@@ -57435,12 +57435,12 @@ You can easily create changeset files using the [Claude Code Plugin provided by 
 **Add marketplace & install changeset plugin**
 \`\`\`
 /plugin marketplace add NaverPayDev/naverpay-plugins
-/plugin install changeset@naverpay-plugins
+/plugin install naverpay-changeset@naverpay-plugins
 \`\`\`
 
 **Usage**
 \`\`\`
-/naverpay-plugins:changeset
+/naverpay-changeset:changeset
 \`\`\`
 
 If you don't use the plugin, you can run the command below to select the changed packages, version type (patch/minor/major), and enter a description.
@@ -57577,23 +57577,23 @@ function getChangesetPluginGuideComment(isKoreanLanguage) {
 **marketplace 추가 & changeset plugin 설치**
 \`\`\`
 /plugin marketplace add NaverPayDev/naverpay-plugins
-/plugin install changeset@naverpay-plugins
+/plugin install naverpay-changeset@naverpay-plugins
 \`\`\`
 
 **사용법**
 \`\`\`
-/naverpay-plugins:changeset
+/naverpay-changeset:changeset
 \`\`\``
         : `### Plugin Usage
 **Add marketplace & install changeset plugin**
 \`\`\`
 /plugin marketplace add NaverPayDev/naverpay-plugins
-/plugin install changeset@naverpay-plugins
+/plugin install naverpay-changeset@naverpay-plugins
 \`\`\`
 
 **Usage**
 \`\`\`
-/naverpay-plugins:changeset
+/naverpay-changeset:changeset
 \`\`\``;
 }
 function getNewChangesetTemplate(changedPackageNames, title, prUrl, versionType) {

--- a/detect-add/src/index.ts
+++ b/detect-add/src/index.ts
@@ -103,12 +103,12 @@ async function main() {
 **marketplace 추가 & changeset plugin 설치**
 \`\`\`
 /plugin marketplace add NaverPayDev/naverpay-plugins
-/plugin install changeset@naverpay-plugins
+/plugin install naverpay-changeset@naverpay-plugins
 \`\`\`
 
 **사용법**
 \`\`\`
-/naverpay-plugins:changeset
+/naverpay-changeset:changeset
 \`\`\`
 
 플러그인을 사용하지 않는다면, 아래 명령어를 실행하면 변경된 패키지와 버전 타입(patch/minor/major)을 선택하고, 변경 내용을 입력할 수 있습니다.
@@ -133,12 +133,12 @@ You can easily create changeset files using the [Claude Code Plugin provided by 
 **Add marketplace & install changeset plugin**
 \`\`\`
 /plugin marketplace add NaverPayDev/naverpay-plugins
-/plugin install changeset@naverpay-plugins
+/plugin install naverpay-changeset@naverpay-plugins
 \`\`\`
 
 **Usage**
 \`\`\`
-/naverpay-plugins:changeset
+/naverpay-changeset:changeset
 \`\`\`
 
 If you don't use the plugin, you can run the command below to select the changed packages, version type (patch/minor/major), and enter a description.

--- a/detect-add/src/utils/changeset.ts
+++ b/detect-add/src/utils/changeset.ts
@@ -13,23 +13,23 @@ function getChangesetPluginGuideComment(isKoreanLanguage: boolean) {
 **marketplace 추가 & changeset plugin 설치**
 \`\`\`
 /plugin marketplace add NaverPayDev/naverpay-plugins
-/plugin install changeset@naverpay-plugins
+/plugin install naverpay-changeset@naverpay-plugins
 \`\`\`
 
 **사용법**
 \`\`\`
-/naverpay-plugins:changeset
+/naverpay-changeset:changeset
 \`\`\``
         : `### Plugin Usage
 **Add marketplace & install changeset plugin**
 \`\`\`
 /plugin marketplace add NaverPayDev/naverpay-plugins
-/plugin install changeset@naverpay-plugins
+/plugin install naverpay-changeset@naverpay-plugins
 \`\`\`
 
 **Usage**
 \`\`\`
-/naverpay-plugins:changeset
+/naverpay-changeset:changeset
 \`\`\``
 }
 


### PR DESCRIPTION
### Issue

- NaverPayDev/changeset-actions#

### Type of Work

- [ ] Bug Fix
- [ ] Feature Addition
- [x] Code Improvement

### Description of Work

- Claude Code Plugin 이름을 `changeset`에서 `naverpay-changeset`으로 변경
- 플러그인 설치 및 사용 명령어를 모두 업데이트 (`/plugin install changeset@naverpay-plugins` → `/plugin install naverpay-changeset@naverpay-plugins`)
- 플러그인 호출 명령어 업데이트 (`/naverpay-plugins:changeset` → `/naverpay-changeset:changeset`)

### Review Points

- detect-add 패키지의 PR 코멘트 생성 로직에서 플러그인 가이드 문구가 올바르게 변경되었는지 확인
- 한국어/영어 가이드 모두 일관되게 업데이트되었는지 확인

### Others
